### PR TITLE
Modifications to work with gpt-3.5-turbo

### DIFF
--- a/main_simple_lib.py
+++ b/main_simple_lib.py
@@ -254,7 +254,8 @@ def load_image(path):
 
 def get_code(query):
     code = forward('codex', prompt=query, input_type="image")
-    code = f'def execute_command(image, my_fig, time_wait_between_lines, syntax):' + code
+    if config.codex.model != 'gpt-3.5-turbo':
+        code = f'def execute_command(image, my_fig, time_wait_between_lines, syntax):' + code # ChatGPT gives execute_command due to its system behaviour
     code_for_syntax = code.replace("(image, my_fig, time_wait_between_lines, syntax)", "(image)")
     syntax_1 = Syntax(code_for_syntax, "python", theme="monokai", line_numbers=True, start_line=0)
     console.print(syntax_1)

--- a/vision_models.py
+++ b/vision_models.py
@@ -932,13 +932,13 @@ def codex_helper(extended_prompt):
                 top_p = 1.,
                 frequency_penalty=0,
                 presence_penalty=0,
-                best_of=config.codex.best_of,
+#                 best_of=config.codex.best_of,
                 stop=["\n\n"],
                 )
                     for prompt in extended_prompt]
         resp = [r['choices'][0]['message']['content'] for r in responses]
-        if len(resp) == 1:
-            resp = resp[0]
+#         if len(resp) == 1:
+#             resp = resp[0]
     else:
         response = openai.Completion.create(
             model="code-davinci-002",

--- a/vision_models.py
+++ b/vision_models.py
@@ -936,7 +936,7 @@ def codex_helper(extended_prompt):
                 stop=["\n\n"],
                 )
                     for prompt in extended_prompt]
-        resp = [r['choices'][0]['message']['content'] for r in responses]
+        resp = [r['choices'][0]['message']['content'].replace("(image)", "(image, my_fig, time_wait_between_lines, syntax)") for r in responses]
 #         if len(resp) == 1:
 #             resp = resp[0]
     else:

--- a/vision_models.py
+++ b/vision_models.py
@@ -936,7 +936,7 @@ def codex_helper(extended_prompt):
                 stop=["\n\n"],
                 )
                     for prompt in extended_prompt]
-        resp = [r['choices'][0]['message']['content'].replace("(image)", "(image, my_fig, time_wait_between_lines, syntax)") for r in responses]
+        resp = [r['choices'][0]['message']['content'].replace("execute_command(image)", "execute_command(image, my_fig, time_wait_between_lines, syntax)") for r in responses]
 #         if len(resp) == 1:
 #             resp = resp[0]
     else:


### PR DESCRIPTION
With codex gone, I was trying to run viper with gpt-3.5-turbo but was facing some errors. I have fixed them here. 

Changes:
1.  ```main_simple_lib.py```: ChatGPT gives def execute_command(image) as its output, I assume because of its system behavior. I've removed prepending the function header in ```get_code```.
2. ```vision_models.py```: Somehow I was not getting an output with ```best_of``` parameter in the API, hence I removed it. Anyway, as per the documentation, it defaults to 1. Also returning the entire output rather than just the first(and only output). Finally, added the line to send back the same parameters in the function definition as expected while using codex.

Hope we can discuss them!
