### PR TITLE
Fix wget download huggingface model

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -6,7 +6,7 @@ PRETRAINED_MODELS_PATH=./pretrained_models
 # GLIP model
 mkdir -p $PRETRAINED_MODELS_PATH/GLIP/checkpoints
 mkdir -p $PRETRAINED_MODELS_PATH/GLIP/configs
-wget -nc -P $PRETRAINED_MODELS_PATH/GLIP/checkpoints https://huggingface.co/GLIPModel/GLIP/blob/main/glip_large_model.pth
+wget -nc -P $PRETRAINED_MODELS_PATH/GLIP/checkpoints https://huggingface.co/GLIPModel/GLIP/resolve/main/glip_large_model.pth
 wget -nc -P $PRETRAINED_MODELS_PATH/GLIP/configs https://raw.githubusercontent.com/microsoft/GLIP/main/configs/pretrain/glip_Swin_L.yaml
 
 # X-VLM model


### PR DESCRIPTION
The original huggingface link doesn't work with `wget`, using the new URL can solve this problem.